### PR TITLE
Implement EffectManager

### DIFF
--- a/SwiftConcurrencySample.xcodeproj/project.pbxproj
+++ b/SwiftConcurrencySample.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		AD507762287FFFBA00009C1D /* StarRepositoryRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD507761287FFFBA00009C1D /* StarRepositoryRequest.swift */; };
 		AD5077642880010700009C1D /* EmptyResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5077632880010700009C1D /* EmptyResponse.swift */; };
 		AD50776628800BAB00009C1D /* CheckStarRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD50776528800BAB00009C1D /* CheckStarRequest.swift */; };
+		AD5BAEFE28B8536A0061680A /* EffectManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5BAEFD28B8536A0061680A /* EffectManager.swift */; };
 		AD695E46287984F500D1C9B5 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD695E45287984F500D1C9B5 /* APIClient.swift */; };
 		AD695E492879AC7700D1C9B5 /* SearchRepositoryRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD695E482879AC7700D1C9B5 /* SearchRepositoryRequest.swift */; };
 		AD695E4C2879AC9600D1C9B5 /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD695E4B2879AC9600D1C9B5 /* Request.swift */; };
@@ -49,6 +50,7 @@
 		AD695E5D2879ADD500D1C9B5 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD695E5C2879ADD500D1C9B5 /* User.swift */; };
 		AD695E5F2879ADEC00D1C9B5 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD695E5E2879ADEC00D1C9B5 /* Repository.swift */; };
 		ADA52A5528978D3B0081876D /* TaskBag.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA52A5428978D3B0081876D /* TaskBag.swift */; };
+		ADF84EF128BB74F600191BFB /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADF84EF028BB74F600191BFB /* Collection.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -87,6 +89,7 @@
 		AD507761287FFFBA00009C1D /* StarRepositoryRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarRepositoryRequest.swift; sourceTree = "<group>"; };
 		AD5077632880010700009C1D /* EmptyResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyResponse.swift; sourceTree = "<group>"; };
 		AD50776528800BAB00009C1D /* CheckStarRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckStarRequest.swift; sourceTree = "<group>"; };
+		AD5BAEFD28B8536A0061680A /* EffectManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectManager.swift; sourceTree = "<group>"; };
 		AD695E45287984F500D1C9B5 /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		AD695E482879AC7700D1C9B5 /* SearchRepositoryRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoryRequest.swift; sourceTree = "<group>"; };
 		AD695E4B2879AC9600D1C9B5 /* Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
@@ -96,6 +99,7 @@
 		AD695E5C2879ADD500D1C9B5 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		AD695E5E2879ADEC00D1C9B5 /* Repository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repository.swift; sourceTree = "<group>"; };
 		ADA52A5428978D3B0081876D /* TaskBag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskBag.swift; sourceTree = "<group>"; };
+		ADF84EF028BB74F600191BFB /* Collection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -329,6 +333,15 @@
 			path = ViewRequests;
 			sourceTree = "<group>";
 		};
+		AD5BAEFF28B853740061680A /* Task */ = {
+			isa = PBXGroup;
+			children = (
+				ADA52A5428978D3B0081876D /* TaskBag.swift */,
+				AD5BAEFD28B8536A0061680A /* EffectManager.swift */,
+			);
+			path = Task;
+			sourceTree = "<group>";
+		};
 		AD695E4128797EFD00D1C9B5 /* API */ = {
 			isa = PBXGroup;
 			children = (
@@ -402,9 +415,18 @@
 		ADA52A5328978D2F0081876D /* Prelude */ = {
 			isa = PBXGroup;
 			children = (
-				ADA52A5428978D3B0081876D /* TaskBag.swift */,
+				ADF84EF228BB74FA00191BFB /* Extension */,
+				AD5BAEFF28B853740061680A /* Task */,
 			);
 			path = Prelude;
+			sourceTree = "<group>";
+		};
+		ADF84EF228BB74FA00191BFB /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				ADF84EF028BB74F600191BFB /* Collection.swift */,
+			);
+			path = Extension;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -494,6 +516,7 @@
 				AD2F2DC4287A59290089DC2D /* SearchRepositoryViewModel.swift in Sources */,
 				AD2D904D288F826B001CAD27 /* UnStarRequest.swift in Sources */,
 				AD2F3ECB287ED2860089DC2D /* ENVClient.swift in Sources */,
+				AD5BAEFE28B8536A0061680A /* EffectManager.swift in Sources */,
 				AD50774C287FA3E600009C1D /* StaredRepositoryView.swift in Sources */,
 				AD695E4C2879AC9600D1C9B5 /* Request.swift in Sources */,
 				AD2F2F63287AB2220089DC2D /* UserDefaultsClientKeys.swift in Sources */,
@@ -509,6 +532,7 @@
 				AD507762287FFFBA00009C1D /* StarRepositoryRequest.swift in Sources */,
 				AD2F2DC2287A57D00089DC2D /* SearchRepositoryHostingController.swift in Sources */,
 				AD695E572879AD6C00D1C9B5 /* UserEntity.swift in Sources */,
+				ADF84EF128BB74F600191BFB /* Collection.swift in Sources */,
 				AD2F2DBA287A56EA0089DC2D /* SearchRepositoryView.swift in Sources */,
 				AD2F32A6287AE54A0089DC2D /* FillColorView.swift in Sources */,
 				AD2F32A3287ACF2F0089DC2D /* RepositoryView.swift in Sources */,

--- a/SwiftConcurrencySample.xcodeproj/project.pbxproj
+++ b/SwiftConcurrencySample.xcodeproj/project.pbxproj
@@ -51,7 +51,18 @@
 		AD695E5F2879ADEC00D1C9B5 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD695E5E2879ADEC00D1C9B5 /* Repository.swift */; };
 		ADA52A5528978D3B0081876D /* TaskBag.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA52A5428978D3B0081876D /* TaskBag.swift */; };
 		ADF84EF128BB74F600191BFB /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADF84EF028BB74F600191BFB /* Collection.swift */; };
+		ADF84EFA28BB8A1D00191BFB /* EffectManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADF84EF928BB8A1D00191BFB /* EffectManagerTests.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		ADF84EFB28BB8A1D00191BFB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AD4CB3A6287978EE0029883B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AD4CB3AD287978EE0029883B;
+			remoteInfo = SwiftConcurrencySample;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		AD2D904C288F826B001CAD27 /* UnStarRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnStarRequest.swift; sourceTree = "<group>"; };
@@ -100,10 +111,19 @@
 		AD695E5E2879ADEC00D1C9B5 /* Repository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Repository.swift; sourceTree = "<group>"; };
 		ADA52A5428978D3B0081876D /* TaskBag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskBag.swift; sourceTree = "<group>"; };
 		ADF84EF028BB74F600191BFB /* Collection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
+		ADF84EF728BB8A1D00191BFB /* SwiftConcurrencySampleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftConcurrencySampleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		ADF84EF928BB8A1D00191BFB /* EffectManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EffectManagerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		AD4CB3AB287978EE0029883B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ADF84EF428BB8A1D00191BFB /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -227,6 +247,7 @@
 			isa = PBXGroup;
 			children = (
 				AD4CB3B0287978EE0029883B /* SwiftConcurrencySample */,
+				ADF84EF828BB8A1D00191BFB /* SwiftConcurrencySampleTests */,
 				AD4CB3AF287978EE0029883B /* Products */,
 			);
 			sourceTree = "<group>";
@@ -235,6 +256,7 @@
 			isa = PBXGroup;
 			children = (
 				AD4CB3AE287978EE0029883B /* SwiftConcurrencySample.app */,
+				ADF84EF728BB8A1D00191BFB /* SwiftConcurrencySampleTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -429,6 +451,14 @@
 			path = Extension;
 			sourceTree = "<group>";
 		};
+		ADF84EF828BB8A1D00191BFB /* SwiftConcurrencySampleTests */ = {
+			isa = PBXGroup;
+			children = (
+				ADF84EF928BB8A1D00191BFB /* EffectManagerTests.swift */,
+			);
+			path = SwiftConcurrencySampleTests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -449,6 +479,24 @@
 			productReference = AD4CB3AE287978EE0029883B /* SwiftConcurrencySample.app */;
 			productType = "com.apple.product-type.application";
 		};
+		ADF84EF628BB8A1D00191BFB /* SwiftConcurrencySampleTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = ADF84EFD28BB8A1D00191BFB /* Build configuration list for PBXNativeTarget "SwiftConcurrencySampleTests" */;
+			buildPhases = (
+				ADF84EF328BB8A1D00191BFB /* Sources */,
+				ADF84EF428BB8A1D00191BFB /* Frameworks */,
+				ADF84EF528BB8A1D00191BFB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				ADF84EFC28BB8A1D00191BFB /* PBXTargetDependency */,
+			);
+			name = SwiftConcurrencySampleTests;
+			productName = SwiftConcurrencySampleTests;
+			productReference = ADF84EF728BB8A1D00191BFB /* SwiftConcurrencySampleTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -456,11 +504,15 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1330;
+				LastSwiftUpdateCheck = 1400;
 				LastUpgradeCheck = 1330;
 				TargetAttributes = {
 					AD4CB3AD287978EE0029883B = {
 						CreatedOnToolsVersion = 13.3.1;
+					};
+					ADF84EF628BB8A1D00191BFB = {
+						CreatedOnToolsVersion = 14.0;
+						TestTargetID = AD4CB3AD287978EE0029883B;
 					};
 				};
 			};
@@ -478,6 +530,7 @@
 			projectRoot = "";
 			targets = (
 				AD4CB3AD287978EE0029883B /* SwiftConcurrencySample */,
+				ADF84EF628BB8A1D00191BFB /* SwiftConcurrencySampleTests */,
 			);
 		};
 /* End PBXProject section */
@@ -489,6 +542,13 @@
 			files = (
 				AD4CB3B9287978EF0029883B /* Preview Assets.xcassets in Resources */,
 				AD4CB3B6287978EF0029883B /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ADF84EF528BB8A1D00191BFB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -544,7 +604,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		ADF84EF328BB8A1D00191BFB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ADF84EFA28BB8A1D00191BFB /* EffectManagerTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		ADF84EFC28BB8A1D00191BFB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = AD4CB3AD287978EE0029883B /* SwiftConcurrencySample */;
+			targetProxy = ADF84EFB28BB8A1D00191BFB /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		AD4CB3D0287978EF0029883B /* Debug */ = {
@@ -719,6 +795,44 @@
 			};
 			name = Release;
 		};
+		ADF84EFE28BB8A1D00191BFB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = y.ryoga.SwiftConcurrencySampleTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SwiftConcurrencySample.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/SwiftConcurrencySample";
+			};
+			name = Debug;
+		};
+		ADF84EFF28BB8A1D00191BFB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = y.ryoga.SwiftConcurrencySampleTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/SwiftConcurrencySample.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/SwiftConcurrencySample";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -736,6 +850,15 @@
 			buildConfigurations = (
 				AD4CB3D3287978EF0029883B /* Debug */,
 				AD4CB3D4287978EF0029883B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		ADF84EFD28BB8A1D00191BFB /* Build configuration list for PBXNativeTarget "SwiftConcurrencySampleTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ADF84EFE28BB8A1D00191BFB /* Debug */,
+				ADF84EFF28BB8A1D00191BFB /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/SwiftConcurrencySample.xcodeproj/xcshareddata/xcschemes/SwiftConcurrencySample.xcscheme
+++ b/SwiftConcurrencySample.xcodeproj/xcshareddata/xcschemes/SwiftConcurrencySample.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AD4CB3AD287978EE0029883B"
+               BuildableName = "SwiftConcurrencySample.app"
+               BlueprintName = "SwiftConcurrencySample"
+               ReferencedContainer = "container:SwiftConcurrencySample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ADF84EF628BB8A1D00191BFB"
+               BuildableName = "SwiftConcurrencySampleTests.xctest"
+               BlueprintName = "SwiftConcurrencySampleTests"
+               ReferencedContainer = "container:SwiftConcurrencySample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AD4CB3AD287978EE0029883B"
+            BuildableName = "SwiftConcurrencySample.app"
+            BlueprintName = "SwiftConcurrencySample"
+            ReferencedContainer = "container:SwiftConcurrencySample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AD4CB3AD287978EE0029883B"
+            BuildableName = "SwiftConcurrencySample.app"
+            BlueprintName = "SwiftConcurrencySample"
+            ReferencedContainer = "container:SwiftConcurrencySample.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SwiftConcurrencySample.xcodeproj/xcshareddata/xcschemes/SwiftConcurrencySampleTests.xcscheme
+++ b/SwiftConcurrencySample.xcodeproj/xcshareddata/xcschemes/SwiftConcurrencySampleTests.xcscheme
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ADF84EF628BB8A1D00191BFB"
+               BuildableName = "SwiftConcurrencySampleTests.xctest"
+               BlueprintName = "SwiftConcurrencySampleTests"
+               ReferencedContainer = "container:SwiftConcurrencySample.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SwiftConcurrencySample/Core/Prelude/Extension/Collection.swift
+++ b/SwiftConcurrencySample/Core/Prelude/Extension/Collection.swift
@@ -1,0 +1,14 @@
+//
+//  Collection.swift
+//  SwiftConcurrencySample
+//
+//  Created by yamamura ryoga on 2022/08/28.
+//
+
+import Foundation
+
+extension Collection {
+    public subscript(safe index: Index) -> Element? {
+        startIndex <= index && index < endIndex ? self[index] : nil
+    }
+}

--- a/SwiftConcurrencySample/Core/Prelude/Task/EffectManager.swift
+++ b/SwiftConcurrencySample/Core/Prelude/Task/EffectManager.swift
@@ -1,0 +1,73 @@
+//
+//  EffectManager.swift
+//  SwiftConcurrencySample
+//
+//  Created by yamamura ryoga on 2022/08/26.
+//
+
+import Foundation
+
+public typealias EffectId = AnyHashable
+
+public protocol EffectIDProtocol: Hashable, Sendable {}
+
+struct DefaultEffectID: EffectIDProtocol {}
+
+public class EffectManager {
+    public typealias CancelableTask = Task<Void, Never>
+    private var effects: [EffectId: Array<CancelableTask>] = [:]
+
+    public init(){}
+
+    public func add<T: EffectIDProtocol>(
+        _ id: T = DefaultEffectID(),
+        task: CancelableTask
+    ) {
+        effects[id, default: []].append(task)
+        
+        Task<Void, Error>.detached {[weak self] in
+            await task.value
+            self?.removeTask(id, task: task)
+        }
+    }
+    
+    private func removeTask<T: EffectIDProtocol>(
+        _ id: T,
+        task: CancelableTask
+    ) {
+        effects[id]?.removeAll(where: { _task in task == _task })
+    }
+    
+    public func cancellAndAdd<T: EffectIDProtocol>(
+        _ id: T = DefaultEffectID(),
+        task: CancelableTask
+    ) {
+        cancell(id)
+        add(
+            id,
+            task: task
+        )
+    }
+
+    public func cancell<T: EffectIDProtocol>(
+        _ id: T
+    ) {
+        if let tasks = effects[id] {
+            for task in tasks {
+                task.cancel()
+            }
+        }
+    }
+
+    public func isCancelled<T: EffectIDProtocol>(
+        _ id: T
+    ) -> Bool {
+        if let tasks = effects[id] {
+            let secondFromLastIndex = tasks.endIndex - 2
+            if let task = tasks[safe: secondFromLastIndex] {
+                return task.isCancelled
+            }
+        }
+        return false
+    }
+}

--- a/SwiftConcurrencySample/Core/Prelude/Task/TaskBag.swift
+++ b/SwiftConcurrencySample/Core/Prelude/Task/TaskBag.swift
@@ -7,16 +7,16 @@
 
 import Foundation
 
-protocol CancelableTaskProtocol {
+public protocol CancelableTaskProtocol {
     func cancel()
 }
 
 extension Task: CancelableTaskProtocol {}
 
-final class TaskBag {
+public final class TaskBag {
     private(set) var tasks: [CancelableTaskProtocol] = []
 
-    func append(_ task: CancelableTaskProtocol) {
+    public func append(_ task: CancelableTaskProtocol) {
         tasks.append(task)
     }
 

--- a/SwiftConcurrencySample/Features/StaredRepository/Logic/StaredRepositoryViewModel.swift
+++ b/SwiftConcurrencySample/Features/StaredRepository/Logic/StaredRepositoryViewModel.swift
@@ -239,14 +239,12 @@ final class StaredRepositoryViewModel: ObservableObject {
                     )
 
                     if effectManager.isCancelled(UpdateUserStaresEffectID()) {
-                        print("キャンセルされたよ")
                         state.isLoading = false
                         return
                     }
 
                     Task.detached { [environment] in
                         do {
-                            print("send api")
                             let response = try await environment.apiClient.send(request)
 
                             Task { @MainActor [weak self] in

--- a/SwiftConcurrencySample/Features/StaredRepository/Logic/StaredRepositoryViewModel.swift
+++ b/SwiftConcurrencySample/Features/StaredRepository/Logic/StaredRepositoryViewModel.swift
@@ -230,6 +230,8 @@ final class StaredRepositoryViewModel: ObservableObject {
             effectManager.cancellAndAdd(
                 UpdateUserStaresEffectID(),
                 task: Task {
+                    
+                    try? await Task.sleep(nanoseconds: 3_000_000_000)
                     state.isLoading = true
 
                     let request = StaredRepositoriesRequest(
@@ -237,12 +239,14 @@ final class StaredRepositoryViewModel: ObservableObject {
                     )
 
                     if effectManager.isCancelled(UpdateUserStaresEffectID()) {
+                        print("キャンセルされたよ")
                         state.isLoading = false
                         return
                     }
 
                     Task.detached { [environment] in
                         do {
+                            print("send api")
                             let response = try await environment.apiClient.send(request)
 
                             Task { @MainActor [weak self] in

--- a/SwiftConcurrencySample/Features/StaredRepository/Logic/StaredRepositoryViewModel.swift
+++ b/SwiftConcurrencySample/Features/StaredRepository/Logic/StaredRepositoryViewModel.swift
@@ -231,7 +231,7 @@ final class StaredRepositoryViewModel: ObservableObject {
                 UpdateUserStaresEffectID(),
                 task: Task {
                     
-                    try? await Task.sleep(nanoseconds: 3_000_000_000)
+                    // try? await Task.sleep(nanoseconds: 3_000_000_000)
                     state.isLoading = true
 
                     let request = StaredRepositoriesRequest(

--- a/SwiftConcurrencySample/Features/StaredRepository/Logic/StaredRepositoryViewModel.swift
+++ b/SwiftConcurrencySample/Features/StaredRepository/Logic/StaredRepositoryViewModel.swift
@@ -230,15 +230,15 @@ final class StaredRepositoryViewModel: ObservableObject {
             effectManager.cancellAndAdd(
                 UpdateUserStaresEffectID(),
                 task: Task {
-                    
-                    // try? await Task.sleep(nanoseconds: 3_000_000_000)
+                    try? await Task.sleep(nanoseconds: 3_000_000_000)
                     state.isLoading = true
 
                     let request = StaredRepositoriesRequest(
                         page: 1
                     )
 
-                    if effectManager.isCancelled(UpdateUserStaresEffectID()) {
+                    
+                    if Task.isCancelled {
                         state.isLoading = false
                         return
                     }

--- a/SwiftConcurrencySampleTests/EffectManagerTests.swift
+++ b/SwiftConcurrencySampleTests/EffectManagerTests.swift
@@ -1,35 +1,156 @@
 //
-//  SwiftConcurrencySampleTests.swift
+//  EffectManagerTests.swift
 //  SwiftConcurrencySampleTests
 //
 //  Created by yamamura ryoga on 2022/08/28.
 //
 
 import XCTest
+@testable import SwiftConcurrencySample
 
-final class SwiftConcurrencySampleTests: XCTestCase {
+
+final class EffectManagerTests: XCTestCase {
+    var effectManager: EffectManager!
+    var exceptValue = 0
+    
 
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        effectManager = EffectManager()
+        exceptValue = 0
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
+    func testAdd() async throws {
+        let expectation = XCTestExpectation(description: "add")
+        expectation.expectedFulfillmentCount = 1
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        measure {
-            // Put the code you want to measure the time of here.
+        let task = Task<Void, Never>.detached {
+            try! await Task.sleep(nanoseconds: 1_000_000_000)
+            expectation.fulfill()
         }
+        // 追加されるか
+        effectManager.add(DefaultEffectID(), task: task)
+        XCTAssertEqual(effectManager.effects[DefaultEffectID()]!.count, 1)
+
+        // taskが成功したら削除されてるか
+        await task.value
+        wait(for: [expectation], timeout: 3.0)
+        XCTAssertEqual(effectManager.effects[DefaultEffectID()]!.count, 0)
+    }
+    
+    func testCancell() async throws {
+        let task = Task<Void, Never>.detached {
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+        }
+        
+        effectManager.add(DefaultEffectID(), task: task)
+        effectManager.cancell(DefaultEffectID())
+        
+        XCTAssertTrue(task.isCancelled)
+    }
+    
+    func testIsCancelled() async throws {
+        let task = Task<Void, Never>.detached {
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+        }
+        
+        effectManager.add(DefaultEffectID(), task: task)
+        effectManager.cancell(DefaultEffectID())
+
+        XCTAssertTrue(effectManager.isCancelled(DefaultEffectID()))
+    }
+    
+    func testCanncellAndAddForCancellCase() async throws {
+        let expectation = XCTestExpectation(description: "cancellAndAdd")
+        expectation.expectedFulfillmentCount = 2
+
+        let task1 = Task<Void, Never>.detached {[weak self] in
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            if self!.effectManager.isCancelled(DefaultEffectID()) == false {
+                self!.exceptValue += 1
+            }
+            expectation.fulfill()
+        }
+        effectManager.cancellAndAdd(DefaultEffectID(), task: task1)
+        
+        let task2 = Task<Void, Never>.detached {[weak self] in
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            if self!.effectManager.isCancelled(DefaultEffectID()) == false {
+                self!.exceptValue += 1
+            }
+            expectation.fulfill()
+        }
+        effectManager.cancellAndAdd(DefaultEffectID(), task: task2)
+        
+        wait(for: [expectation], timeout: 10.0)
+        XCTAssertEqual(exceptValue, 1)
+    }
+    
+    func testCanncellAndAddForNotCancellCase() async throws {
+        let expectation = XCTestExpectation(description: "cancellAndAdd")
+        expectation.expectedFulfillmentCount = 2
+
+        let task1 = Task<Void, Never>.detached {[weak self] in
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            if self!.effectManager.isCancelled(DefaultEffectID()) == false {
+                self!.exceptValue += 1
+            }
+            expectation.fulfill()
+        }
+        effectManager.cancellAndAdd(DefaultEffectID(), task: task1)
+        
+        try? await Task.sleep(nanoseconds: 1_500_000_000)
+        
+        let task2 = Task<Void, Never>.detached {[weak self] in
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            if self!.effectManager.isCancelled(DefaultEffectID()) == false {
+                self!.exceptValue += 1
+            }
+            expectation.fulfill()
+        }
+        effectManager.cancellAndAdd(DefaultEffectID(), task: task2)
+        
+        wait(for: [expectation], timeout: 10.0)
+        XCTAssertEqual(exceptValue, 2)
     }
 
+    
+    func testCanncellAndAddThreeTime() async throws {
+        let expectation = XCTestExpectation(description: "cancellAndAdd")
+        expectation.expectedFulfillmentCount = 3
+
+        let task1 = Task<Void, Never>.detached {[weak self] in
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            if self!.effectManager.isCancelled(DefaultEffectID()) == false {
+                self!.exceptValue += 1
+            }
+            expectation.fulfill()
+        }
+        effectManager.cancellAndAdd(DefaultEffectID(), task: task1)
+        
+//        try? await Task.sleep(nanoseconds: 1_500_000_000)
+        
+        let task2 = Task<Void, Never>.detached {[weak self] in
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            if self!.effectManager.isCancelled(DefaultEffectID()) == false {
+                self!.exceptValue += 1
+            }
+            expectation.fulfill()
+        }
+        effectManager.cancellAndAdd(DefaultEffectID(), task: task2)
+        
+//        try? await Task.sleep(nanoseconds: 1_500_000_000)
+        
+        let task3 = Task<Void, Never>.detached {[weak self] in
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            if self!.effectManager.isCancelled(DefaultEffectID()) == false {
+                self!.exceptValue += 1
+            }
+            expectation.fulfill()
+        }
+        effectManager.cancellAndAdd(DefaultEffectID(), task: task3)
+
+        
+        wait(for: [expectation], timeout: 10.0)
+        XCTAssertEqual(exceptValue, 1)
+    }
 }

--- a/SwiftConcurrencySampleTests/EffectManagerTests.swift
+++ b/SwiftConcurrencySampleTests/EffectManagerTests.swift
@@ -23,146 +23,157 @@ final class EffectManagerTests: XCTestCase {
         let expectation = XCTestExpectation(description: "add")
         expectation.expectedFulfillmentCount = 1
 
-        let task = Task<Void, Never>.detached {
-            try! await Task.sleep(nanoseconds: 1_000_000_000)
+        // 追加されるか
+        effectManager.add(DefaultEffectID()) {
+            try? await Task.sleep(nanoseconds: 500_000_000)
             expectation.fulfill()
         }
-        // 追加されるか
-        effectManager.add(DefaultEffectID(), task: task)
         XCTAssertEqual(effectManager.effects[DefaultEffectID()]!.count, 1)
 
-        // taskが成功したら削除されてるか
+        // taskの完了を待って削除されてるか
+        let task = effectManager.effects[DefaultEffectID()]!.first!
         await task.value
         wait(for: [expectation], timeout: 3.0)
         XCTAssertEqual(effectManager.effects[DefaultEffectID()]!.count, 0)
     }
     
     func testCancell() async throws {
-        let task = Task<Void, Never>.detached {
+        effectManager.add(DefaultEffectID()) {
             try? await Task.sleep(nanoseconds: 2_000_000_000)
         }
-        
-        effectManager.add(DefaultEffectID(), task: task)
+
+        let task = effectManager.effects[DefaultEffectID()]!.first!
         effectManager.cancell(DefaultEffectID())
-        
+
         XCTAssertTrue(task.isCancelled)
     }
-        
+
     func testAllCancell() async throws {
-        let task1 = Task<Void, Never>.detached {
+        effectManager.add(DefaultEffectID()) {
             try? await Task.sleep(nanoseconds: 2_000_000_000)
         }
-        effectManager.add(DefaultEffectID(), task: task1)
+        let task1 = effectManager.effects[DefaultEffectID()]!.first!
 
-        let task2 = Task<Void, Never>.detached {
+
+        effectManager.add(DefaultEffectID()) {
             try? await Task.sleep(nanoseconds: 2_000_000_000)
         }
-        effectManager.add(DefaultEffectID(), task: task2)
+        let task2 = effectManager.effects[DefaultEffectID()]![1]
 
-
-        let task3 = Task<Void, Never>.detached {
+        effectManager.add(DefaultEffectID()) {
             try? await Task.sleep(nanoseconds: 2_000_000_000)
         }
-        effectManager.add(DefaultEffectID(), task: task3)
+        let task3 = effectManager.effects[DefaultEffectID()]![2]
 
         effectManager.cancell(DefaultEffectID())
         XCTAssertTrue(task1.isCancelled)
         XCTAssertTrue(task2.isCancelled)
         XCTAssertTrue(task3.isCancelled)
     }
-    
+
+    // cancel回数が正しいか
     func testCanncellAndAddForCancellCase() async throws {
         let expectation = XCTestExpectation(description: "cancellAndAdd")
         expectation.expectedFulfillmentCount = 2
 
-        let task1 = Task<Void, Never>.detached {[weak self] in
+        effectManager.cancellAndAdd(DefaultEffectID()) {
             try? await Task.sleep(nanoseconds: 1_000_000_000)
             if Task.isCancelled {
-                self!.exceptValue += 1
+                self.exceptValue += 1
             }
             expectation.fulfill()
         }
-        effectManager.cancellAndAdd(DefaultEffectID(), task: task1)
-        
-        let task2 = Task<Void, Never>.detached {[weak self] in
+        let task1 = effectManager.effects[DefaultEffectID()]!.first!
+
+        effectManager.cancellAndAdd(DefaultEffectID()) {
             try? await Task.sleep(nanoseconds: 1_000_000_000)
             if Task.isCancelled {
-                self!.exceptValue += 1
+                self.exceptValue += 1
             }
             expectation.fulfill()
         }
-        effectManager.cancellAndAdd(DefaultEffectID(), task: task2)
-        
-        wait(for: [expectation], timeout: 10.0)
+        // この時点で2回目のcanncellAndAddが呼ばれてるので、taskの配列からtask1は削除されてるためindexは0
+        let task2 = effectManager.effects[DefaultEffectID()]!.first!
+        _ = (await task1.value, await task2.value)
+
+        wait(for: [expectation], timeout: 5.0)
         XCTAssertEqual(exceptValue, 1)
     }
-    
+
+    // cancel回数(exceptValue)が正しいか
     func testCanncellAndAddForNotCancellCase() async throws {
         let expectation = XCTestExpectation(description: "cancellAndAdd")
         expectation.expectedFulfillmentCount = 2
 
-        let task1 = Task<Void, Never>.detached {[weak self] in
+        effectManager.cancellAndAdd(DefaultEffectID()) {
             try? await Task.sleep(nanoseconds: 1_000_000_000)
-            if Task.isCancelled == false {
-                self!.exceptValue += 1
+            if Task.isCancelled {
+                self.exceptValue += 1
             }
             expectation.fulfill()
         }
-        effectManager.cancellAndAdd(DefaultEffectID(), task: task1)
+        let task1 = effectManager.effects[DefaultEffectID()]!.first!
         
+        // task1の完了を待つ
         try? await Task.sleep(nanoseconds: 1_500_000_000)
-        
-        let task2 = Task<Void, Never>.detached {[weak self] in
+
+        effectManager.cancellAndAdd(DefaultEffectID()) {
             try? await Task.sleep(nanoseconds: 1_000_000_000)
-            if Task.isCancelled == false {
-                self!.exceptValue += 1
+            if Task.isCancelled {
+                self.exceptValue += 1
             }
             expectation.fulfill()
         }
-        effectManager.cancellAndAdd(DefaultEffectID(), task: task2)
-        
+        // この時点でtask1は完了してるので、taskの配列からtask1は削除されてるためindexは0
+        let task2 = effectManager.effects[DefaultEffectID()]![0]
+
+        // task1の完了を待ってからcancellAndAdd呼び出すので、exceptValueは0に
+        _ = (await task1.value, await task2.value)
         wait(for: [expectation], timeout: 10.0)
-        XCTAssertEqual(exceptValue, 2)
+        XCTAssertEqual(exceptValue, 0)
     }
 
-    
+
     func testCanncellAndAddThreeTime() async throws {
         let expectation = XCTestExpectation(description: "cancellAndAdd")
         expectation.expectedFulfillmentCount = 3
 
-        let task1 = Task<Void, Never>.detached {[weak self] in
+        effectManager.cancellAndAdd(DefaultEffectID()) {
             try? await Task.sleep(nanoseconds: 1_000_000_000)
-            if Task.isCancelled == false {
-                self!.exceptValue += 1
+            if Task.isCancelled {
+                self.exceptValue += 1
             }
             expectation.fulfill()
         }
-        effectManager.cancellAndAdd(DefaultEffectID(), task: task1)
-        
-        try? await Task.sleep(nanoseconds: 1_500_000_000)
-        
-        let task2 = Task<Void, Never>.detached {[weak self] in
-            try? await Task.sleep(nanoseconds: 1_000_000_000)
-            if Task.isCancelled == false {
-                self!.exceptValue += 1
-            }
-            expectation.fulfill()
-        }
-        effectManager.cancellAndAdd(DefaultEffectID(), task: task2)
-        
-//        try? await Task.sleep(nanoseconds: 1_500_000_000)
-        
-        let task3 = Task<Void, Never>.detached {[weak self] in
-            try? await Task.sleep(nanoseconds: 1_000_000_000)
-            if Task.isCancelled == false {
-                self!.exceptValue += 1
-            }
-            expectation.fulfill()
-        }
-        effectManager.cancellAndAdd(DefaultEffectID(), task: task3)
+        let task1 = effectManager.effects[DefaultEffectID()]!.first!
 
-        
+        // task1の完了を待つ
+        try? await Task.sleep(nanoseconds: 1_500_000_000)
+
+        effectManager.cancellAndAdd(DefaultEffectID()) {
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            if Task.isCancelled {
+                self.exceptValue += 1
+            }
+            expectation.fulfill()
+        }
+        let task2 = effectManager.effects[DefaultEffectID()]!.first!
+
+        // task2の完了を待つ場合
+//        try? await Task.sleep(nanoseconds: 1_500_000_000)
+
+        effectManager.cancellAndAdd(DefaultEffectID()) {
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            if Task.isCancelled {
+                self.exceptValue += 1
+            }
+            expectation.fulfill()
+        }
+        let task3 = effectManager.effects[DefaultEffectID()]!.first!
+
+        _ = (await task1.value, await task2.value, await task3.value)
         wait(for: [expectation], timeout: 10.0)
-        XCTAssertEqual(exceptValue, 2)
+        // task2のみキャンセルするので
+        XCTAssertEqual(exceptValue, 1)
     }
 }

--- a/SwiftConcurrencySampleTests/EffectManagerTests.swift
+++ b/SwiftConcurrencySampleTests/EffectManagerTests.swift
@@ -47,16 +47,28 @@ final class EffectManagerTests: XCTestCase {
         
         XCTAssertTrue(task.isCancelled)
     }
-    
-    func testIsCancelled() async throws {
-        let task = Task<Void, Never>.detached {
+        
+    func testAllCancell() async throws {
+        let task1 = Task<Void, Never>.detached {
             try? await Task.sleep(nanoseconds: 2_000_000_000)
         }
-        
-        effectManager.add(DefaultEffectID(), task: task)
-        effectManager.cancell(DefaultEffectID())
+        effectManager.add(DefaultEffectID(), task: task1)
 
-        XCTAssertTrue(effectManager.isCancelled(DefaultEffectID()))
+        let task2 = Task<Void, Never>.detached {
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+        }
+        effectManager.add(DefaultEffectID(), task: task2)
+
+
+        let task3 = Task<Void, Never>.detached {
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+        }
+        effectManager.add(DefaultEffectID(), task: task3)
+
+        effectManager.cancell(DefaultEffectID())
+        XCTAssertTrue(task1.isCancelled)
+        XCTAssertTrue(task2.isCancelled)
+        XCTAssertTrue(task3.isCancelled)
     }
     
     func testCanncellAndAddForCancellCase() async throws {
@@ -65,7 +77,7 @@ final class EffectManagerTests: XCTestCase {
 
         let task1 = Task<Void, Never>.detached {[weak self] in
             try? await Task.sleep(nanoseconds: 1_000_000_000)
-            if self!.effectManager.isCancelled(DefaultEffectID()) == false {
+            if Task.isCancelled {
                 self!.exceptValue += 1
             }
             expectation.fulfill()
@@ -74,7 +86,7 @@ final class EffectManagerTests: XCTestCase {
         
         let task2 = Task<Void, Never>.detached {[weak self] in
             try? await Task.sleep(nanoseconds: 1_000_000_000)
-            if self!.effectManager.isCancelled(DefaultEffectID()) == false {
+            if Task.isCancelled {
                 self!.exceptValue += 1
             }
             expectation.fulfill()
@@ -91,7 +103,7 @@ final class EffectManagerTests: XCTestCase {
 
         let task1 = Task<Void, Never>.detached {[weak self] in
             try? await Task.sleep(nanoseconds: 1_000_000_000)
-            if self!.effectManager.isCancelled(DefaultEffectID()) == false {
+            if Task.isCancelled == false {
                 self!.exceptValue += 1
             }
             expectation.fulfill()
@@ -102,7 +114,7 @@ final class EffectManagerTests: XCTestCase {
         
         let task2 = Task<Void, Never>.detached {[weak self] in
             try? await Task.sleep(nanoseconds: 1_000_000_000)
-            if self!.effectManager.isCancelled(DefaultEffectID()) == false {
+            if Task.isCancelled == false {
                 self!.exceptValue += 1
             }
             expectation.fulfill()
@@ -120,18 +132,18 @@ final class EffectManagerTests: XCTestCase {
 
         let task1 = Task<Void, Never>.detached {[weak self] in
             try? await Task.sleep(nanoseconds: 1_000_000_000)
-            if self!.effectManager.isCancelled(DefaultEffectID()) == false {
+            if Task.isCancelled == false {
                 self!.exceptValue += 1
             }
             expectation.fulfill()
         }
         effectManager.cancellAndAdd(DefaultEffectID(), task: task1)
         
-//        try? await Task.sleep(nanoseconds: 1_500_000_000)
+        try? await Task.sleep(nanoseconds: 1_500_000_000)
         
         let task2 = Task<Void, Never>.detached {[weak self] in
             try? await Task.sleep(nanoseconds: 1_000_000_000)
-            if self!.effectManager.isCancelled(DefaultEffectID()) == false {
+            if Task.isCancelled == false {
                 self!.exceptValue += 1
             }
             expectation.fulfill()
@@ -142,7 +154,7 @@ final class EffectManagerTests: XCTestCase {
         
         let task3 = Task<Void, Never>.detached {[weak self] in
             try? await Task.sleep(nanoseconds: 1_000_000_000)
-            if self!.effectManager.isCancelled(DefaultEffectID()) == false {
+            if Task.isCancelled == false {
                 self!.exceptValue += 1
             }
             expectation.fulfill()
@@ -151,6 +163,6 @@ final class EffectManagerTests: XCTestCase {
 
         
         wait(for: [expectation], timeout: 10.0)
-        XCTAssertEqual(exceptValue, 1)
+        XCTAssertEqual(exceptValue, 2)
     }
 }

--- a/SwiftConcurrencySampleTests/EffectManagerTests.swift
+++ b/SwiftConcurrencySampleTests/EffectManagerTests.swift
@@ -1,0 +1,35 @@
+//
+//  SwiftConcurrencySampleTests.swift
+//  SwiftConcurrencySampleTests
+//
+//  Created by yamamura ryoga on 2022/08/28.
+//
+
+import XCTest
+
+final class SwiftConcurrencySampleTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}


### PR DESCRIPTION
ベタConcurrencyのロジック部分(viewmodel)で使うためのEffectManagerを実装
sequenceなどは対応せずTaskのみ対応

taskの登録(実行)、実行中のtaskのキャンセル、実行中のタスクをキャンセルして再度実行